### PR TITLE
Add tip to use custom fonts in Quarto.

### DIFF
--- a/06-tips-workflow.Rmd
+++ b/06-tips-workflow.Rmd
@@ -31,9 +31,10 @@ If you are saving raster files such as .png and .jpeg, make sure to set the desi
 
 The iterative process of adjusting your graphic, saving it to disk, navigating to the folder, and looking at the plot is a tedious one. To avoid the additional workload, you can optimize your workflow by previewing your graphic in the correct dimensions without leaving RStudio.
 
-***Work in Quarto (.qmd) or Rmarkdown (.rmd) files to inspect your plots in-line:*** In qmd and rmd formats, code is run inside individual chunks for which you can define figure dimensions by setting `fig.width` or `fig.height` as chunk options [^06-tips-1].
+***Work in Quarto (.qmd) or Rmarkdown (.Rmd) files to inspect your plots in-line:*** In qmd and Rmd formats, code is run inside individual chunks for which you can define figure dimensions by setting `fig.width` or `fig.height` as chunk options [^06-tips-1].
 
 ````{verbatim 06chunkSettings}
+
 ```{r, fig.width=12, fig.height=8}
 ```
 ````
@@ -86,7 +87,22 @@ ggsave("plot.png", device = agg_png)
 
 To make fonts work in the RStudio Plots pane, select the AGG device as default for the graphics backend by navigating to `Tools > Global Options... > General > Graphics`.
 
-***If you are saving your graphics as PDF vector graphics use the cairo_pdf device:*** I prefer to dave my files as lossless vector graphics. The device known to work best for rendering is the Cairo device which needs to be secified as `device = cairo_pdf`. Mac users need to install [XQuartz](https://www.xquartz.org/) which is needed to use the Cairo device.
+To make fonts work in Quarto documents, you can add the following to the [yaml header](https://quarto.org/docs/computations/execution-options.html#knitr-options)
+
+```yaml
+knitr:
+  opts_chunk: 
+    dev: ragg_png
+
+```
+
+In R Markdown documents, you have to put the following in a code chunk.
+
+```{r 06rmdAGG, eval=FALSE}
+knitr::opts_chunk$set(dev = "ragg_png")
+```
+
+***If you are saving your graphics as PDF vector graphics use the cairo_pdf device:*** I prefer to save my files as lossless vector graphics. The device known to work best for rendering is the Cairo device which needs to be secified as `device = cairo_pdf`. Mac users need to install [XQuartz](https://www.xquartz.org/) which is needed to use the Cairo device.
 
 ```{r 06ggsaveCairo, eval=FALSE}
 ggsave("plot.pdf", device = cairo_pdf)

--- a/_output.yml
+++ b/_output.yml
@@ -8,7 +8,7 @@ bookdown::gitbook:
       after: |
         <hr class="grey"><li><i><a href="https://bookdown.org" target="blank">Published with bookdown</a></i></li>
     download: [pdf, epub]
-    edit: https://github.com/yihui/bookdown-crc/edit/master/%s
+    edit: https://github.com/z3tt/graphic-design-ggplot2/edit/main/%s
     sharing:
       github: true
       facebook: false

--- a/book.bib
+++ b/book.bib
@@ -32,7 +32,7 @@
   year = {2015},
   edition = {2nd},
   note = {ISBN 978-1498716963},
-  url = {http://yihui.name/knitr/}
+  url = {http://yihui.org/knitr/}
 }
 @article{sciaini2018,
   title = {NLMR and landscapetools: An integrated environment for simulating and modifying neutral landscape models in R},


### PR DESCRIPTION
Add a tip on how to use custom fonts with Quarto and Rmd documents. 

Without those, custom fonts are not rendered in Qmd or Rmd documents (at least on Windows, so I thought it would be interesting to mention this here)

Change link to edit this page to the repo!

I would suggest also to add the link to the github homepage https://z3tt.github.io/graphic-design-ggplot2
in the about section
![image](https://github.com/z3tt/graphic-design-ggplot2/assets/52606734/7db016b5-3dfd-4a05-ac11-64b9137d38df)

Also a typo that I caught on the fly
I prefer to dave -> I prefer to save